### PR TITLE
Fix bridging header

### DIFF
--- a/ios/BleManager.mm
+++ b/ios/BleManager.mm
@@ -1,5 +1,5 @@
 #import <BleManager.h>
-#import <RNBleManager-Swift.h>
+#import <RNBleManager/RNBleManager-Swift.h>
 
 @implementation SpecChecker
 


### PR DESCRIPTION
According to [Apple](https://developer.apple.com/documentation/swift/importing-swift-into-objective-c), the Swift->Objective-C bridging header syntax is:

```#import <ProductName/ProductModuleName-Swift.h>```

... where the `ProductName` is `RNBleManager` in this case. Before this change, I got `file not found` errors in Xcode. After the change, the bridging header is created and included.